### PR TITLE
Issue 3: missing dependency for Jetty in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <commons.io.version>2.1</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.logging.version>1.1.1</commons.logging.version>
+        <jetty.version>6.1.26</jetty.version>
         <log4j.version>1.2.16</log4j.version>
 
     </properties>
@@ -102,6 +103,12 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>${log4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jetty</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Patch to fix [issue 3](https://github.com/alexholmes/hdfs-file-slurper/issues/3).
