### PR TITLE
In & Out streams are closed into the finally statment, no need to ask Utils.copyBytes to close them

### DIFF
--- a/src/main/java/com/alexholmes/hdfsslurper/WorkerThread.java
+++ b/src/main/java/com/alexholmes/hdfsslurper/WorkerThread.java
@@ -164,7 +164,7 @@ public class WorkerThread extends Thread {
           os = config.getCodec().createOutputStream(os);
         }
 
-        IOUtils.copyBytes(is, os, 4096, true);
+        IOUtils.copyBytes(is, os, 4096, false);
       } finally {
         IOUtils.closeStream(is);
         IOUtils.closeStream(os);


### PR DESCRIPTION
...Utils.copyBytes to close them
